### PR TITLE
chore: 更新.gitignore以排除新的模型和结果文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ trainData/*
 Verify/*
 models/*
 prediction_results.csv
+Alphafold*
+result*
+models*


### PR DESCRIPTION
在.gitignore中添加了对以"Alphafold"和"result"开头的文件及目录的忽略规则，以保持项目整洁。